### PR TITLE
clear out interval timers in willDestroyElement in case not completed…

### DIFF
--- a/exp-player/addon/components/exp-lookit-video/component.js
+++ b/exp-player/addon/components/exp-lookit-video/component.js
@@ -965,6 +965,9 @@ export default ExpFrameBaseComponent.extend(FullScreen, MediaReload, VideoRecord
 
     willDestroyElement() { // remove event handler
         $(document).off('keyup.pauser');
+        window.clearInterval(this.get('testTimer'));
+        window.clearInterval(this.get('announceTimer'));
+        window.clearInterval(this.get('calTimer'));
         this._super(...arguments);
     }
 });


### PR DESCRIPTION
… in finish(), to avoid ongoing errors throughout experiment as the referenced element has been destroyed


